### PR TITLE
vendor: Spoof build fingerprint for Google Play Services [2/2]

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -139,3 +139,10 @@ PRODUCT_COPY_FILES += \
 PRODUCT_COPY_FILES += \
     vendor/aicp/prebuilt/common/lib/libsketchology_native.so:$(TARGET_COPY_OUT_SYSTEM)/lib/libsketchology_native.so \
     vendor/aicp/prebuilt/common/lib64/libsketchology_native.so:$(TARGET_COPY_OUT_SYSTEM)/lib64/libsketchology_native.so
+
+# Spoof fingerprint for Google Play Services and SafetyNet
+ifeq ($(PRODUCT_OVERRIDE_GMS_FINGERPRINT),)
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.build.gms_fingerprint=Xiaomi/dipper/dipper:8.1.0/OPM1.171019.011/V9.5.5.0.OEAMIFA:user/release-keys
+else
+PRODUCT_SYSTEM_DEFAULT_PROPERTIES += ro.build.gms_fingerprint=$(PRODUCT_OVERRIDE_GMS_FINGERPRINT)
+endif


### PR DESCRIPTION
SafetyNet's CTS profile attestation checks whether Build.FINGERPRINT matches that of the device's stock OS, which has passed CTS testing. Spoof the fingerprint for Google Play Services to help pass SafetyNet.

NB: This code is under the gmscompat package, but it does not depend on any code from gmscompat.

arrow edits:
 - Correct prop name for our logic. We are planning use fp for different devices (like old oreo or follow new Pixel's).
 - Use PRODUCT_SYSTEM_DEFAULT_PROPERTIES for avoid error: ADDITIONAL_SYSTEM_PROPERTIES must not set before here.
 - Spoof dipper oreo fp
 - To override fp for GMS, add in device tree: PRODUCT_OVERRIDE_GMS_FINGERPRINT := your fingerprint

Signed-off-by: palaych <palaych@arrowos.net>
Change-Id: I862487adf736f499802b345b0044fb34ac204dd6